### PR TITLE
require a minimum of one value from permissions array

### DIFF
--- a/src/modules/users/schema.ts
+++ b/src/modules/users/schema.ts
@@ -16,7 +16,7 @@ const permissionsEnum = [
 export const createUserSchema = z.object({
   email: z.string().email(),
   name: z.string().nonempty(),
-  permissions: z.array(z.enum(permissionsEnum)),
+  permissions: z.array(z.enum(permissionsEnum)).min(1),
   role: z.enum(roleEnum),
 });
 


### PR DESCRIPTION
Modified the user schema to require the permissions property to have at least one value from the array.